### PR TITLE
docker support and .htaccess reroutes

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,5 @@
+RewriteEngine on
+RewriteRule ^ext/images/(.*)$ ext/images/$1 [L]
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule . index.php [L]

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -1,0 +1,12 @@
+# Setup (Docker)
+The Docker image will automatically download tested versions of php, apache, mariadb and phpmyadmin:
+
+- php:8.3-apache
+- mariadb:10.11
+- phpmyadmin:latest
+
+It will also automatically configure them.
+
+You'll still have to set the Database credentials: You can do so by changing the environment variables for mariadb in `/docker-compose.yml` and by modifying the variables in `/_database.php`. Just remember that these have to stay the same.  
+
+There is also the need to configure write permissions for the `ext/images` folder. You can do so by running `$ chmod -R a+wr ext/images` on the host system.  This wasn't possible to automate, as the entire repo is mounted as a volume.

--- a/apache_docker/Dockerfile
+++ b/apache_docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:8.3-apache
+RUN docker-php-ext-install pdo_mysql mysqli
+RUN a2enmod rewrite
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  web:
+    build: './apache_docker'
+    container_name: apache-huechan
+    ports:
+      - "80:80"
+    volumes:
+      - ./:/var/www/html
+  mariadb:
+    image: mariadb:10.11
+    container_name: mariadb-huechan
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: mariadb-huechan
+      MYSQL_ROOT_PASSWORD: root-password
+      MYSQL_USER: myuser
+      MYSQL_PASSWORD: password
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./setup.sql:/docker-entrypoint-initdb.d/setup.sql
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:latest
+    ports:
+      - 8080:80
+    environment:
+      PMA_HOST: mariadb
+    depends_on:
+      - mariadb
+volumes:
+  db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - ./setup.sql:/docker-entrypoint-initdb.d/setup.sql
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:latest
+    container_name: phpmyadmin-huechan
     ports:
       - 8080:80
     environment:


### PR DESCRIPTION
this pr adds instance setup through docker, and, also adds an `.htaccess` file, which allows automatic rerouting of the following requests:

- `/ext/images/*` > `/ext/images/`
- `/*` > `/index.php` 

this would make installation much easier, even for setups without the use of docker (note that you'd need to enable the `.htaccess` in your apache configuration).